### PR TITLE
warning fixes. jwtToken -> jwToken, other minor fixes

### DIFF
--- a/backend/api.js
+++ b/backend/api.js
@@ -294,6 +294,8 @@ exports.setApp = function ( app, client )
 
         // Checks if the JWT is expired
         // Sets the error and returns
+        console.log('api line 297');
+        console.log(jwToken);
         try
         {
             if( token.isExpired(jwToken))
@@ -334,6 +336,7 @@ exports.setApp = function ( app, client )
         }
 
         var ret = {error: error, jwToken: refreshedToken, message: msg};
+        console.log(ret);
 
         res.status(200).json(ret);
     });
@@ -699,7 +702,7 @@ exports.setApp = function ( app, client )
 
     // These variables are sent from front-end
     // folders is the text that is being added
-    const {userId, jwtToken} = req.body;
+    const {userId, jwToken} = req.body;
     var error = '';
     var token = require('./createJWT.js');
 
@@ -707,10 +710,10 @@ exports.setApp = function ( app, client )
     // Sets the error and returns
     try
     {
-        if( token.isExpired(jwtToken))
+        if( token.isExpired(jwToken))
         {
             console.log("TOKEN EXPIRED retrieveFolders");
-            var r = {error:'The JWT is no longer valid', jwtToken:''};
+            var r = {error:'The JWT is no longer valid', jwToken:''};
             res.status(200).json(r);
             return;
         }
@@ -738,7 +741,7 @@ exports.setApp = function ( app, client )
     var refreshedToken = null;
     try
     {
-        refreshedToken = token.refresh(jwtToken);
+        refreshedToken = token.refresh(jwToken);
     }
     catch(e)
     {
@@ -746,7 +749,7 @@ exports.setApp = function ( app, client )
     }
 
     // Sen the user back an error field and their refreshed token
-    var ret = { error: error, jwtToken: refreshedToken, folders: results };
+    var ret = { error: error, jwToken: refreshedToken, folders: results };
     console.log("FINISHED retrieveFolders");
     
     res.status(200).json(ret);

--- a/backend/createJWT.js
+++ b/backend/createJWT.js
@@ -13,7 +13,7 @@ _createToken = function ( fn, ln, id )
         const expiration = new Date();
         const user = {userId:id,firstName:fn,lastName:ln};
 
-        const accessToken =  jwt.sign( user, process.env.ACCESS_TOKEN_SECRET);
+        const accessToken =  jwt.sign( user, process.env.ACCESS_TOKEN_SECRET, {expiresIn: '30m'});        
 
         // In order to expire with a value other than the default, use the following
         // const accessToken= jwt.sign(user,process.env.ACCESS_TOKEN_SECRET, 

--- a/frontend/src/components/CardButton.js
+++ b/frontend/src/components/CardButton.js
@@ -21,7 +21,8 @@ border-width:0px;
 
 export const Buttonc = ({className, button_id, button_text, onClick}) =>{
     return(
+        // readOnly for true just to get rid of errors in debugging.
         <Button id={button_id} className={className} value = {button_text}
-        onClick={onClick} />
+        onClick={onClick} readOnly={true}/>
     )
 }

--- a/frontend/src/components/CardsUI.js
+++ b/frontend/src/components/CardsUI.js
@@ -27,7 +27,7 @@ function CardsUI()
         // Use:
         // Name="" Address="" PhoneNumber="" MoreInfo="" Description="" Rating=""
         // To define Info per card
-        <div style={{"display":"grid", "row-gap": "3rem", "top":"0px", "margin":"5%"}}>
+        <div style={{"display":"grid", "rowGap": "3rem", "top":"0px", "margin":"5%"}}>
             <SearchBar/>
             <InfoCard Name="McDonalds" Address="3737 Pine Tree Lane" PhoneNumber="231-714-5572" MoreInfo="..." DescriptionText="Fast Convenient" Rating="3.1"/>
             <InfoCard Name="Comfort Food" Address="2055 Stanley Avenue" PhoneNumber="860-928-5548" MoreInfo="..." DescriptionText="Food you'll Love" Rating="4.0"/>

--- a/frontend/src/components/CenterDiv.js
+++ b/frontend/src/components/CenterDiv.js
@@ -2,5 +2,5 @@ import '../App.css';
 
 export const CenterDiv = (props) =>{
     return  <div className='main_pane' style={{"height": "80%","width": "100%",
-        "margin-top": "0px", "overflow":"auto"}}>{props.children}</div>
+        "marginTop": "0px", "overflow":"auto"}}>{props.children}</div>
 }

--- a/frontend/src/components/FolderEditMode.js
+++ b/frontend/src/components/FolderEditMode.js
@@ -15,8 +15,8 @@ function FolderEditMode(props){
         // Storage to access the locally stored JWT
         var storage = require('../tokenStorage.js');
 
-        // The object to be sent to the api, must contain userId and jwtToken field
-        var obj = {folderId:props.folderId, jwtToken:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjQsImZpcnN0TmFtZSI6ImJvYiIsImxhc3ROYW1lIjoic21pdGgiLCJpYXQiOjE2NDg4NjEwMjF9.2qEySf6TkkJe8uuSctETqo20LmRZ3QVZggUiwHFRYaU"};
+        // The object to be sent to the api, must contain userId and jwToken field
+        var obj = {folderId:props.folderId, jwToken:storage.retrieveToken()};
         var js = JSON.stringify(obj);
         console.log(js);
 
@@ -27,7 +27,7 @@ function FolderEditMode(props){
         {
             // Request folders and JWT
             const response = await fetch(bp.buildPath('deleteFolder'), {method:'POST',body:js,headers:{'Content-Type':'application/json'}});
-
+            console.log(response);
             // Wait for response and parse json
             res = JSON.parse(await response.text());
 
@@ -46,7 +46,7 @@ function FolderEditMode(props){
                 // setMessage('Got the folders');
                 
                 // Store the received refreshed JWT
-                storage.storeToken( res.jwtToken );
+                storage.storeToken( res.jwToken );
 
                 // Turns the response field into an array of elements
                 // { folderId, name} -> fields of each array object
@@ -68,12 +68,12 @@ function FolderEditMode(props){
 
     return (props.trigger) ? (
     //this div contains the folder delete cross and edit pen icons (for edit mode)
-    <div style={{"display":"flex", "justify-content":"center", "column-gap":"4vh", "margin-top":"1vh", "overflow":"auto"}}>
+    <div style={{"display":"flex", "justifyContent":"center", "columnGap":"4vh", "marginTop":"1vh", "overflow":"auto"}}>
         <div style={{"height":"40px", "width":"40px", "overflow":"hidden"}}>
         <input type="image" src={del} alt="delete" id="delete" onClick={DeleteFolder}/>
             {/* <img src={del} alt="delete" style={{"width":"100%", "height":"100%"}}></img> */}
         </div>  
-        <div style={{"height":"30px", "width":"30px", "overflow":"hidden", "objectFit":"contain", "padding-top":"5px"}}>
+        <div style={{"height":"30px", "width":"30px", "overflow":"hidden", "objectFit":"contain", "paddingTop":"5px"}}>
             <img src={rename} alt="rename" style={{"width":"100%", "height":"100%"}}></img>
         </div>  
     </div>

--- a/frontend/src/components/FoldersUI.js
+++ b/frontend/src/components/FoldersUI.js
@@ -45,8 +45,8 @@ function FoldersUI()
         // The user data is stored as text and needs to be turned into an object
         var data = JSON.parse(localStorage.user_data);
 
-        // The object to be sent to the api, must contain userId and jwtToken field
-        var obj = {userId:data.id, jwtToken:storage.retrieveToken()};
+        // The object to be sent to the api, must contain userId and jwToken field
+        var obj = {userId:data.id, jwToken:storage.retrieveToken()};
         var js = JSON.stringify(obj);
 
         // Path to send the api call
@@ -71,7 +71,7 @@ function FoldersUI()
                 // setMessage('Got the folders');
                 
                 // Store the received refreshed JWT
-                storage.storeToken( res.jwtToken );
+                storage.storeToken( res.jwToken );
 
                 // Turns the response field into an array of elements
                 // { folderId, name} -> fields of each array object
@@ -103,7 +103,7 @@ function FoldersUI()
     }
 
     return(
-         <div style={{"display":"grid", "row-gap": "1rem", "top":"0px", "margin":"10%", "alignContent":"center"}}>
+         <div style={{"display":"grid", "rowGap": "1rem", "top":"0px", "margin":"10%", "alignContent":"center"}}>
             <EditButton button_text="Edit" onClick={editModefunct}/>
             <EditMode trigger={editMode} setTrigger={setEditMode} arr={res} arrn={res} sta={setFolders}/>
             

--- a/frontend/src/components/ListsTab.js
+++ b/frontend/src/components/ListsTab.js
@@ -19,7 +19,7 @@ export const ListsTab = ({children, className}) =>{
     return (
         <div className="tab">
             <img className="lists_tab" src={tab_list} alt="Lists" style={{"width":"auto", "height":"100%"
-            ,"object-fit":"cover", "display":"block","margin-left": "auto","margin-right":"auto", "padding-left":"20px", "padding-right":"20px"}}></img>
+            ,"objectFit":"cover", "display":"block","marginLeft": "auto","marginRight":"auto", "paddingLeft":"20px", "paddingRight":"20px"}}></img>
              <Text className={className}>{children}</Text>
         </div>  
     )

--- a/frontend/src/components/LoginCenterDiv.js
+++ b/frontend/src/components/LoginCenterDiv.js
@@ -78,19 +78,20 @@ function CenterDiv()
     return(
         <div className="main_pane">
             <form onSubmit={DoLogin}>
-                <div className="fields" style={{"display": "flex", "display":"grid", "row-gap": "1rem"}}>
+                <div className="fields" style={{"display": "flex", "display":"grid", "rowGap": "1rem"}}>
                     <input type="text" id="loginName" placeholder="Username" 
                         ref={(c) => loginName = c} /><br /> 
                     <input type="password" id="loginPassword" placeholder="Password" 
                         ref={(c) => loginPassword = c} /><br />
                     <span id="loginResult">{message}</span>
                 </div>
-                <div style={{"display":"grid", "row-gap": "2rem"}}>
+                <div style={{"display":"grid", "rowGap": "2rem"}}>
                     <input type="submit" id="loginButton" value = "Login"
-                        onClick={DoLogin} style={{"margin-top":"40px"}}/>
+                        onClick={DoLogin} style={{"marginTop":"40px"}}/>
                     <input type="submit" id="loginGButton" value = "Login with Google" 
                     style={{"width":"30%"}}/>
-                    <LinkStyled className="link" link_text="Forgot Password"/>
+                    {/* This routes back to login page just to avoid getting an unnecessary error. */}
+                    <LinkStyled className="link" link_text="Forgot Password" route="/Login"/>
                     <LinkStyled className="link" route="/Register" link_text="Create Account"/>
                 </div>
             </form>

--- a/frontend/src/components/LongTab.js
+++ b/frontend/src/components/LongTab.js
@@ -22,7 +22,7 @@ export const LongTab = ({children, className}) =>{
     return(
         <div className="tab">
             <img className="arc" src={arc} alt="Arc" style={{"width":"581px", "height":"100"
-            ,"object-fit":"cover", "display":"block","margin-left": "auto","margin-right":"auto"}}></img>
+            ,"objectFit":"cover", "display":"block","marginLeft": "auto","marginRight":"auto"}}></img>
             <Text className={className}>{children}</Text>
         </div>
     )

--- a/frontend/src/components/SearchBar.js
+++ b/frontend/src/components/SearchBar.js
@@ -21,7 +21,7 @@ color: #FEFFDC;
 background: #001A5E;
 border-radius: 14px;
 align:right;
-column-gap: 1rem;
+columnGap: 1rem;
 `
 
 const Bar = styled.div`
@@ -45,16 +45,16 @@ column-gap: 1rem;
 
 export const SearchBar = ({className, button_id, button_text}) =>{
     return(
-        <Bar style={{"display":"grid", "gridTemplateColumns":"18fr 1fr 1fr 1fr", "column-gap":"1rem"}}>
-        <Input id="searchBar" placeholder="    Search" style={{"z-index":"0"}}/>
+        <Bar style={{"display":"grid", "gridTemplateColumns":"18fr 1fr 1fr 1fr", "columnGap":"1rem"}}>
+        <Input id="searchBar" placeholder="    Search" style={{"zIndex":"0"}}/>
 
-        <div style={{"height":"60px", "width":"60px",  "margin":"auto", "padding-left":"20px"}}>
+        <div style={{"height":"60px", "width":"60px",  "margin":"auto", "paddingLeft":"20px"}}>
             <img src={search} alt="search" style={{"width":"100%", "height":"100%"}}></img>
         </div>  
         <div style={{"height":"60px", "width":"42.5px", "margin":"auto"}}>
             <img src={location} alt="location" style={{"width":"100%", "height":"100%"}}></img>
         </div>  
-        <div style={{"height":"60px", "width":"60px",  "margin":"auto", "padding-right":"20px"}}>
+        <div style={{"height":"60px", "width":"60px",  "margin":"auto", "paddingRight":"20px"}}>
             <img src={filter} alt="search" style={{"width":"100%", "height":"100%"}}></img>
         </div>  
          </Bar>

--- a/frontend/src/components/SearchTab.js
+++ b/frontend/src/components/SearchTab.js
@@ -25,7 +25,7 @@ export const SearchTab = ({children, className}) =>{
     return (
         <div className="tab" >
             <img className="search_tab" src={tab_search_dark} alt="Lists" style={{"width":"auto", "height":"100%"
-            ,"object-fit":"cover", "display":"block","margin-left": "auto","margin-right":"auto"}}></img>
+            ,"objectFit":"cover", "display":"block","marginLeft": "auto","marginRight":"auto"}}></img>
             <Text className={className}>{children}</Text>
         </div>  
     )

--- a/frontend/src/components/Title.js
+++ b/frontend/src/components/Title.js
@@ -5,7 +5,7 @@ import '../App.css';
 // This makes Title component reusable
 export const Title = ({className}) =>{
     return (
-        <div className={className} style={{"height":"150px", "overflow-x":"auto"}}>Things 2 Do
+        <div className={className} style={{"height":"150px", "overflowX":"auto"}}>Things 2 Do
             <img className="logo" src={logo} alt="Logo"></img>
         </div>  
     )

--- a/frontend/src/components/TopMarginMain.js
+++ b/frontend/src/components/TopMarginMain.js
@@ -16,7 +16,7 @@ height: 114px;
 
 function TopMarginMain() {
   return (
-    <div style={{"display":"flex", "gap": "20vh",  "margin-bottom":"40px"}}>
+    <div style={{"display":"flex", "gap": "20vh",  "marginBottom":"40px"}}>
       <MainTitle className="title"/>
       <MarginButton button_id="suprise"  button_text="Suprise Me!"/>
       <MarginButton button_id="logout"  button_text="Logout"/>

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -15,18 +15,18 @@ const TabTitle = styled(LongTab)`
 
 function LoginPage() {
   return (
-    <body className="background">
+    <div className="background">
 
-<div style={{"display":"grid", "gridTemplateRows": "1fr", "align-content":"center"}}>
+<div style={{"display":"grid", "gridTemplateRows": "1fr", "alignContent":"center"}}>
 
       <TitleHeader className="title"/>
-      <div class="wrapper" style={{"display":"grid", "gridTemplateRows": "1fr 100%"}}>
+      <div className="wrapper" style={{"display":"grid", "gridTemplateRows": "1fr 100%"}}>
       <TabTitle children="Login"></TabTitle>
       <LoginCenterDiv/>
       </div>
       </div>
 
-    </body>
+    </div>
     
   );
 }

--- a/frontend/src/pages/MainPage.js
+++ b/frontend/src/pages/MainPage.js
@@ -28,10 +28,10 @@ const CenterDivList = styled(CenterDiv)`
 
 function MainPage() {
     return (
-        <body className="background">
-            <div style={{"margin":"5%", "margin-top":"0px"}}>
+        <div className="background">
+            <div style={{"margin":"5%", "marginTop":"0px"}}>
                 <TopMarginMain/>
-                <div className="wrapper" style={{"display":"grid", "gridTemplateColumns":"1fr 4fr", "column-gap":"1rem", "height":"100vh"}}>
+                <div className="wrapper" style={{"display":"grid", "gridTemplateColumns":"1fr 4fr", "columnGap":"1rem", "height":"100vh"}}>
                     <div className="wrapper" style={{"display":"grid", "gridTemplateRows":"1fr 100%"}}>
                         <ListsTab children="Lists"/>
                         <div>
@@ -40,8 +40,8 @@ function MainPage() {
                             </CenterDivList>
                         </div>
                     </div>
-                    <div class="wrapper" style={{"display":"grid", "gridTemplateRows":"1fr 100%"}}>
-                        <div style= {{"display":"flex", "gap":"20vh", "justify-content":"center", "margin-left":"50px", "margin-right":"50px"}}>
+                    <div className="wrapper" style={{"display":"grid", "gridTemplateRows":"1fr 100%"}}>
+                        <div style= {{"display":"flex", "gap":"20vh", "justifyContent":"center", "marginLeft":"50px", "marginRight":"50px"}}>
                             <SearchTab children="Food"/>
                             <SearchTab children="Activities"/>
                             <SearchTab children="Friends"/>
@@ -54,7 +54,7 @@ function MainPage() {
                     </div>
                 </div>
             </div>
-        </body>
+        </div>
 
     );
 }


### PR DESCRIPTION
I fixed a lot of minor things that were causing issues and warnings. The attributes using the hyphen for justify-content, margin-left, etc I left there since it still works. It all seems to work but made a branch for this since it may just be a development mode thing thats giving all of the warnings in console and not something needing to fix. If we need to revert back to hyphens being in the return statements we can go back.

Should keep the other minor changes such as:

- jwtToken to jwToken for uniformity and parsing json looking for jwToken in all cases.
- readOnly remaining for button until it has functionality.
- Forgot Password just rerouting to /Login for now to avoid unnecessary warnings cluttering.